### PR TITLE
add key holder

### DIFF
--- a/context.go
+++ b/context.go
@@ -41,7 +41,6 @@ var ctxOptionsKey ctxOptions
 // to skip the cache entry on Query.
 //
 //	client.T.Query().All(entcache.Skip(ctx))
-//
 func Skip(ctx context.Context) context.Context {
 	c, ok := ctx.Value(ctxOptionsKey).(*ctxOptions)
 	if !ok {
@@ -55,13 +54,11 @@ func Skip(ctx context.Context) context.Context {
 // to skip and invalidate the cache entry on Query.
 //
 //	client.T.Query().All(entcache.Evict(ctx))
-//
 func Evict(ctx context.Context) context.Context {
 	c, ok := ctx.Value(ctxOptionsKey).(*ctxOptions)
 	if !ok {
-		return context.WithValue(ctx, ctxOptionsKey, &ctxOptions{skip: true, evict: true})
+		return context.WithValue(ctx, ctxOptionsKey, &ctxOptions{evict: true})
 	}
-	c.skip = true
 	c.evict = true
 	return ctx
 }
@@ -71,7 +68,6 @@ func Evict(ctx context.Context) context.Context {
 // more than 1 SQL query (e.g. eager loading).
 //
 //	client.T.Query().All(entcache.WithKey(ctx, "key"))
-//
 func WithKey(ctx context.Context, key Key) context.Context {
 	c, ok := ctx.Value(ctxOptionsKey).(*ctxOptions)
 	if !ok {
@@ -84,7 +80,6 @@ func WithKey(ctx context.Context, key Key) context.Context {
 // WithTTL returns a new Context that carries the TTL for the cache entry.
 //
 //	client.T.Query().All(entcache.WithTTL(ctx, time.Second))
-//
 func WithTTL(ctx context.Context, ttl time.Duration) context.Context {
 	c, ok := ctx.Value(ctxOptionsKey).(*ctxOptions)
 	if !ok {


### PR DESCRIPTION
Hi @a8m 

Inspired by [cachops](https://github.com/Suor/django-cacheops), i add key holders which created in `onClose` function. Each holder is equivalent with record(s). It make easier to evict keys, which are related to record(s).

Example:
```go
expectQuery(evictCtx, t, drv, "SELECT name FROM users LIMIT 1 OFFSET 0", []interface{}{"a8m"}) // evicted
expectQuery(ctx, t, drv, "SELECT name FROM users", []interface{}{"a8m", "a9m"}) // evicted too
expectQuery(ctx, t, drv, "SELECT name FROM users LIMIT 1 OFFSET 1", []interface{}{"a9m"}) // still in cache
```

Its also related to issue #13. When update a record with `UpdateOne`, [ent](https://entgo.io/) will fetch record after updating.
```go
u := client.T.Get(ctx, id)
u, _ = u.Update().SetName("nottest").Save(entcache.Evict(ctx))
```

[graph.go](https://github.com/ent/ent/blob/35e950edf98a8eaefd6de381d752c25f0de8f0f7/dialect/sql/sqlgraph/graph.go#L667)
```go
	if !update.Empty() {
		var res sql.Result
		query, args := update.Query()
		if err := tx.Exec(ctx, query, args, &res); err != nil {
			return err
		}
		...
	}
	...
	rows := &sql.Rows{}
	query, args := selector.Query()
	if err := tx.Query(ctx, query, args, rows); err != nil {
		return err
	}
	return u.scan(rows)
```