### PR TITLE
Fix concurrency issue

### DIFF
--- a/level.go
+++ b/level.go
@@ -75,7 +75,7 @@ var ErrNotFound = errors.New("entcache: entry was not found")
 type (
 	// LRU provides an LRU cache that implements the AddGetter interface.
 	LRU struct {
-		mu sync.RWMutex
+		mu sync.Mutex
 		*lru.Cache
 	}
 	// entry wraps the Entry with additional expiry information.
@@ -115,9 +115,9 @@ func (l *LRU) Add(_ context.Context, k Key, e *Entry, ttl time.Duration) error {
 
 // Get gets an entry from the cache.
 func (l *LRU) Get(_ context.Context, k Key) (*Entry, error) {
-	l.mu.RLock()
+	l.mu.Lock()
 	e, ok := l.Cache.Get(k)
-	l.mu.RUnlock()
+	l.mu.Unlock()
 	if !ok {
 		return nil, ErrNotFound
 	}


### PR DESCRIPTION
Hi 👋

PR #19 improved the support for concurrent actions but seems like there is still an issue, it's not easy to reproduce (in a single, fast test), it took almost one year to first be observed by me, I managed to create a test for it:

```go
func TestA(t *testing.T) {
	c := NewLRU(3)
	var wg sync.WaitGroup
	for i := 0; i < 100; i++ {
		for j := 0; j < 100; j++ {
			wg.Add(1)
			go func(i int) {
				key := fmt.Sprintf("test_%d", i)
				_, err := c.Get(context.TODO(), key)
				if errors.Is(err, ErrNotFound) {
					_ = c.Add(context.TODO(), key, &Entry{}, 1*time.Millisecond)
				}
				wg.Done()
			}(i)
		}
	}
	wg.Wait()
}
```

```
panic: interface conversion: interface {} is nil, not *lru.entry

goroutine 76046 [running]:
github.com/golang/groupcache/lru.(*Cache).removeElement(0x705c00?, 0xc000423e10?)
        /home/pedro/go/pkg/mod/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da/lru/lru.go:108 +0x11b
github.com/golang/groupcache/lru.(*Cache).RemoveOldest(0x6d9380?)
        /home/pedro/go/pkg/mod/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da/lru/lru.go:102 +0x3b
github.com/golang/groupcache/lru.(*Cache).Add(0xc0004fe840, {0x6c5dc0?, 0xc002ae7010}, {0x6dd600?, 0xc002330440})
        /home/pedro/go/pkg/mod/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da/lru/lru.go:69 +0x425
ariga.io/entcache.(*LRU).Add(0xc0004fe880, {0x7?, 0x7b7120?}, {0x6c5dc0, 0xc002ae7010}, 0xc0011adf88, 0xf4240)
        /home/pedro/code/entcache/level.go:111 +0x249
ariga.io/entcache.TestA.func1(0x0?)
        /home/pedro/code/entcache/a_test.go:22 +0x130
created by ariga.io/entcache.TestA
        /home/pedro/code/entcache/a_test.go:18 +0x12c
FAIL    ariga.io/entcache       2.346s
FAIL
```

I have to run it with `repeat 100 go test -count=100 .` otherwise sometimes it will not be observed.

The fix is an easy one, we only have to use a `Mutex`, I pretty sure the problem is related to the way `Get/MoveToFront` works, in other words, `Get` is mutating the value, so we can not use a `RLock`.

I have not added a test for it, since the test above is a flaky one, but suggestions for other ways of testing it are welcome.

See:
- https://github.com/golang/groupcache/issues/59
- https://github.com/golang/groupcache/pull/163